### PR TITLE
restructured output dirs

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -45,7 +45,7 @@ process {
     withName: '.*:CRAMINO_PRE' {
         ext.args   = '--ubam'
         publishDir = [
-            path: { "${params.outdir}/qc/cramino_ubam" },
+            path: { "${params.outdir}/${meta.id}/${meta.type}/qc/cramino_ubam" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -53,7 +53,7 @@ process {
 
     withName: '.*:CRAMINO_POST' {
         publishDir = [
-            path: { "${params.outdir}/qc/cramino_aln" },
+            path: { "${params.outdir}/${meta.id}/${meta.type}/qc/cramino_aln" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -61,7 +61,7 @@ process {
 
     withName: '.*:MODKIT_PILEUP' {
         publishDir = [
-            path: { "${params.outdir}/methylation/modkit_pileup" },
+            path: { "${params.outdir}/${meta.id}/${meta.type}/methylation/modkit_pileup" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -70,7 +70,7 @@ process {
     withName: '.*:FIBERTOOLSRS_QC' {
         ext.args   = { params.autocorrelation ? "--acf" : '' }
         publishDir = [
-            path: { "${params.outdir}/methylation/fibertoolsrs/qc" },
+            path: { "${params.outdir}/${meta.id}/${meta.type}/qc/fibertoolsrs" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -78,7 +78,7 @@ process {
 
     withName: '.*:MOSDEPTH' {
         publishDir = [
-            path: { "${params.outdir}/qc/mosdepth" },
+            path: { "${params.outdir}/${meta.id}/${meta.type}/qc/mosdepth" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -92,7 +92,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/methylation/fibertoolsrs/predictm6a" },
+            path: { "${params.outdir}/${meta.id}/${meta.type}/methylation/fibertoolsrs/predictm6a" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -101,7 +101,7 @@ process {
     withName: '.*:SEVERUS' {
         ext.args = '--min-support 3'
         publishDir = [
-            path: { "${params.outdir}/variants/severus" },
+            path: { "${params.outdir}/${meta.id}/variants/severus" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -119,7 +119,7 @@ process {
     withName: '.*:FIBERTOOLSRS_FIRE' {
         ext.args   = { params.ont_data ? "--ont" : '' } //TODO: this won't work. Need to import this module twice with different args
         publishDir = [
-            path: { "${params.outdir}/methylation/fibertoolsrs/fire" },
+            path: { "${params.outdir}/${meta.id}/${meta.type}/methylation/fibertoolsrs/fire" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -128,7 +128,7 @@ process {
     withName: '.*:CLAIRSTO_ont' {
         ext.args   = { "--platform ont_r10_dorado_sup_5khz_ssrs"}
         publishDir = [
-            path: { "${params.outdir}/variants/clairsto" },
+            path: { "${params.outdir}/${meta.id}/variants/clairsto" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -31,8 +31,8 @@ process {
         ext.prefix = { "${meta.id}_mapped" } 
         ext.args = {
             [
-                "$meta.method == 'pb'" ? ( params.minimap2_pb_model ? "-ax $params.minimap2_pb_model" : "-ax map-hifi" ) : 
-                ( params.minimap2_ont_model ? "-ax $params.minimap2_ont_model" : "-ax map-lr:hq " ),
+                meta.method == 'pb' ? ( params.minimap2_pb_model ? "-ax $params.minimap2_pb_model" : "-ax map-hifi" ) : 
+                ( params.minimap2_ont_model ? "-ax $params.minimap2_ont_model" : "-ax lr:hq " ),
                 params.save_secondary_alignment ? "--secondary=yes " : "--secondary=no "
             ].join(' ').trim()
         }
@@ -45,7 +45,7 @@ process {
     withName: '.*:CRAMINO_PRE' {
         ext.args   = '--ubam'
         publishDir = [
-            path: { "${params.outdir}/${meta.id}/${meta.type}/qc/cramino_ubam" },
+            path: { "${params.outdir}/qc/cramino_ubam" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -53,7 +53,7 @@ process {
 
     withName: '.*:CRAMINO_POST' {
         publishDir = [
-            path: { "${params.outdir}/${meta.id}/${meta.type}/qc/cramino_aln" },
+            path: { "${params.outdir}/qc/cramino_aln" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -61,7 +61,7 @@ process {
 
     withName: '.*:MODKIT_PILEUP' {
         publishDir = [
-            path: { "${params.outdir}/${meta.id}/${meta.type}/methylation/modkit_pileup" },
+            path: { "${params.outdir}/methylation/modkit_pileup" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -70,7 +70,7 @@ process {
     withName: '.*:FIBERTOOLSRS_QC' {
         ext.args   = { params.autocorrelation ? "--acf" : '' }
         publishDir = [
-            path: { "${params.outdir}/${meta.id}/${meta.type}/qc/fibertoolsrs" },
+            path: { "${params.outdir}/methylation/fibertoolsrs/qc" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -78,7 +78,7 @@ process {
 
     withName: '.*:MOSDEPTH' {
         publishDir = [
-            path: { "${params.outdir}/${meta.id}/${meta.type}/qc/mosdepth" },
+            path: { "${params.outdir}/qc/mosdepth" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -92,7 +92,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/${meta.id}/${meta.type}/methylation/fibertoolsrs/predictm6a" },
+            path: { "${params.outdir}/methylation/fibertoolsrs/predictm6a" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -101,7 +101,7 @@ process {
     withName: '.*:SEVERUS' {
         ext.args = '--min-support 3'
         publishDir = [
-            path: { "${params.outdir}/${meta.id}/variants/severus" },
+            path: { "${params.outdir}/variants/severus" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -119,7 +119,7 @@ process {
     withName: '.*:FIBERTOOLSRS_FIRE' {
         ext.args   = { params.ont_data ? "--ont" : '' } //TODO: this won't work. Need to import this module twice with different args
         publishDir = [
-            path: { "${params.outdir}/${meta.id}/${meta.type}/methylation/fibertoolsrs/fire" },
+            path: { "${params.outdir}/methylation/fibertoolsrs/fire" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -128,7 +128,7 @@ process {
     withName: '.*:CLAIRSTO_ont' {
         ext.args   = { "--platform ont_r10_dorado_sup_5khz_ssrs"}
         publishDir = [
-            path: { "${params.outdir}/${meta.id}/variants/clairsto" },
+            path: { "${params.outdir}/variants/clairsto" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]


### PR DESCRIPTION
Some quick restructuring of output directories.
basically restructured to:
`outdir/samplename/variants/`
`outdir/samplename/normal/qc`
`outdir/samplename/tumor/qc`

etc.

<!--
# IntGenomicsLab/lr_somatic pull request

Many thanks for contributing to IntGenomicsLab/lr_somatic!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/IntGenomicsLab/lr_somatic/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/IntGenomicsLab/lr_somatic/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
