### PR TITLE
Return longphase output

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -190,6 +190,9 @@ process {
     withName: '.*:LONGPHASE_PHASE' {
         ext.args   = {meta.platform == 'pb' ? '--pb' : '--ont'}
         publishDir = [
+            path: { "${params.outdir}/${meta.id}/variants/phased_normal" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             enabled: false
         ]
     }


### PR DESCRIPTION
On reflection, useful to have phased vcf outputted, especially given we haven't gotten wakhan running yet and this is required input for it

<!--
# IntGenomicsLab/lr_somatic pull request

Many thanks for contributing to IntGenomicsLab/lr_somatic!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/IntGenomicsLab/lr_somatic/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/IntGenomicsLab/lr_somatic/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
